### PR TITLE
Fixed incompatible casting in fast inverse sqrt

### DIFF
--- a/code/mathematical_algorithms/src/fast_inverse_sqrt/fast_inverse_sqrt.cpp
+++ b/code/mathematical_algorithms/src/fast_inverse_sqrt/fast_inverse_sqrt.cpp
@@ -13,7 +13,7 @@ double fastInverseSqrt(double x)
     float xhalf = 0.5f * x;
     int i = *(int*)&x;              // get bits for floating value
     i = 0x5f375a86 - (i >> 1);      // gives initial guess y0
-    x = *(float*)&i;                // convert bits back to float
+    x = reinterpret_cast<float>(i);                // convert bits back to float
     x = x * (1.5f - xhalf * x * x); // Newton step, repeating increases accuracy
     return x;
 }


### PR DESCRIPTION
**Fixes issue:** #13 
<!-- [Mention the issue number it fixes or add the details of the changes if it doesn't has a specific issue. -->


**Changes:**
- Integer to float cast is done by reinterpret_cast instead of C-style cast.
<!-- Add here what changes were made in this pull request. -->


<!-- Make sure to look at the Style Guide for your language in guides/coding_style/language_name:

     https://github.com/OpenGenus/cosmos/tree/master/guides/coding_style

     Note: A coding style guide may not exist for your language, since this is still in beta.
-->

<!-- Make sure to look at the Documentation Style Guide in guides/documentation.md:

     https://github.com/OpenGenus/cosmos/blob/master/guides/documentation_guide.md

     The document style guide may not apply for your algorithm category, you must also look at specified guide under all of the directory in the category, e.g., for project euler:

     https://github.com/OpenGenus/cosmos/blob/master/code/online_challenges/src/project_euler/documentation_guide.md
-->
